### PR TITLE
Output Option Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Squire - Get Answers with Llama
 
-Use [llama.cpp](https://github.com/ggerganov/llama.cpp) with [LangChain](https://docs.langchain.com/docs/) tools to answer a query. This script is based on the [Custom Agent with Tool Retreival](https://python.langchain.com/en/latest/modules/agents/agents/custom_agent_with_tool_retrieval.html) example from LangChain, with prompt engineering and output parsing modifications to better accomodate Llama models. Squire has been tested with [wizardLM-7B](https://huggingface.co/TheBloke/wizardLM-7B-GGML) and [llama-30b-supercot-ggml](https://huggingface.co/gozfarb/llama-30b-supercot-ggml). Runs as a command line script.
+Use [llama.cpp](https://github.com/ggerganov/llama.cpp) with [LangChain](https://docs.langchain.com/docs/) tools to answer a query. This script is based on the [Custom Agent with Tool Retreival](https://python.langchain.com/en/latest/modules/agents/agents/custom_agent_with_tool_retrieval.html) example from LangChain, with prompt engineering and output parsing modifications to better accomodate Llama models. Runs as a command line script.
 
 ## Installation
 
@@ -20,8 +20,9 @@ Command line options for external files:
 | Option  | Description | Default |
 | ------------- | ------------- | ------------- |
 | -q --question | path to a *.txt file containing your question | question.txt |
-| --template | path to template *.txt file | template.txt |
-| --l | path to ggml model weights *.bin file | wizardLM-7B.GGML.q4_2.bin |
+| -m --template | path to template *.txt file | template.txt |
+| -l --llama_path| path to ggml model weights *.bin file | wizardLM-7B.GGML.q4_2.bin |
+| -o --output | path to output file for the final answer | out.txt |
 
 There are also options to control what parameters the LangChain `LlamaCpp()` forwards to llama.cpp:
 
@@ -37,9 +38,7 @@ Miscellaneous:
 
 | Option  | Description |
 | ------------- | ------------- |
-| -v --verbose | verbose output |
-
-At present, output is printed into the CLI.
+| -v --verbose | verbose output (partially working) |
 
 ## Operation
 
@@ -51,7 +50,7 @@ Squire will ingest default or provided parameters. Assuming this is successful, 
 - Requests
 - PythonREPL
 
-It may take the model several cycles of queries and attempted queries before it obtains satisfactory date to use in a final answer. Once it does obtain adequate data, Squire will issue a final answer in the CLI.
+It may take the model several cycles of queries and attempted queries before it obtains satisfactory data to use in a final answer. Once it does obtain adequate data, Squire will write it to the output file and in command line. Squire has been tested with [wizardLM-7B](https://huggingface.co/TheBloke/wizardLM-7B-GGML) and [llama-30b-supercot-ggml](https://huggingface.co/gozfarb/llama-30b-supercot-ggml), giving answers to the best of its ability. Note that the quality of the output and efficiency of operation will be greatly affected by your choice of local language model.
 
 ## Afterword
   

--- a/question.txt
+++ b/question.txt
@@ -1,1 +1,1 @@
-What is the current temperaturew in Winnipeg?
+What is the current temperature in Winnipeg?

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,8 @@ huggingface-hub==0.14.1
 idna==3.4
 Jinja2==3.1.2
 joblib==1.2.0
-langchain==0.0.153
-llama-cpp-python==0.1.39
+langchain==0.0.154
+llama-cpp-python==0.1.41
 lz4==4.3.2
 MarkupSafe==2.1.2
 marshmallow-enum==1.5.1
@@ -66,13 +66,13 @@ scikit-build==0.17.3
 scikit-learn==1.2.2
 scipy==1.10.1
 sentence-transformers==2.2.2
-sentencepiece==0.1.98
+sentencepiece==0.1.99
 setuptools==67.7.2
 sgmllib3k==1.0.0
 six==1.16.0
 sniffio==1.3.0
 soupsieve==2.4.1
-SQLAlchemy==2.0.11
+SQLAlchemy==2.0.12
 starlette==0.26.1
 swig==4.1.1
 sympy==1.11.1

--- a/squire.py
+++ b/squire.py
@@ -47,7 +47,7 @@ parser.add_argument('-m', '--template', type=str, default='template.txt',
 parser.add_argument('-l', '--llama_path', type=str, default='wizardLM-7B.GGML.q4_2.bin',
                     help='path to ggml model weights *.bin file')
 parser.add_argument('-o', '--output', type=str, default='out.txt',
-                    help='path to ggml model weights *.bin file')
+                    help='path to output file for the final answer')
 parser.add_argument('-p', '--top_p', type=float, default=0.95)
 parser.add_argument('-k', '--top_k', type=float, default=40)
 parser.add_argument('-T', '--temperature', type=float, default=0.2)


### PR DESCRIPTION
Update with the following changes:

- Output now printed to 'out.txt'. 
- Output filename can be set with '-o' or '--output'. 
- Add single-letter '-m' option for template file. 
- Continuing to work on proper implementation of 'verbose' as originally envisioned - it is difficult to suppress llama.cpp timings. 
- Minor prompt engineering change. 
- Fix typo in example question.
- Bump requirements. 
- Begin changing how tools are handled in preparation for LangChain0.0.155 and beyond. 
- Update readme.